### PR TITLE
inconsistent check for output buffer size and output speedup

### DIFF
--- a/src/routers/iq_router.cpp
+++ b/src/routers/iq_router.cpp
@@ -1044,7 +1044,7 @@ void IQRouter::_SWHoldUpdate( )
     
     int const expanded_output = item.second.second;
     
-    if(expanded_output >= 0 && ( _output_buffer_size==-1 || _output_buffer[expanded_output].size()<size_t(_output_buffer_size))) {
+    if(expanded_output >= 0 && ( _output_buffer_size==-1 || _output_buffer[expanded_output/_output_speedup].size()<size_t(_output_buffer_size))) {
       
       assert(_switch_hold_in[expanded_input] == expanded_output);
       assert(_switch_hold_out[expanded_output] == expanded_input);
@@ -1193,7 +1193,7 @@ void IQRouter::_SWHoldUpdate( )
     } else {
       //when internal speedup >1.0, the buffer stall stats may not be accruate
       assert((expanded_output == STALL_BUFFER_FULL) ||
-	     (expanded_output == STALL_BUFFER_RESERVED) || !( _output_buffer_size==-1 || _output_buffer[expanded_output].size()<size_t(_output_buffer_size)));
+	     (expanded_output == STALL_BUFFER_RESERVED) || !( _output_buffer_size==-1 || _output_buffer[expanded_output/_output_speedup].size()<size_t(_output_buffer_size)));
 
       int const held_expanded_output = _switch_hold_in[expanded_input];
       assert(held_expanded_output >= 0);


### PR DESCRIPTION
The output buffer checking is inconsistent in iq_router.cpp.

It is initialized to _output_buffer.resize(_outputs), however, two places are checked using expanded_output, which can lead to wrong execution and affect the result if output_speedup is used.
