### PR TITLE
Add minimal & load-balanced oblivious routing to routefunc.cpp

### DIFF
--- a/src/examples/load_balanced_oblivious_torus
+++ b/src/examples/load_balanced_oblivious_torus
@@ -1,0 +1,17 @@
+// Load-Balanced Oblivious Routing Configuration for 8x8 Torus
+
+// Topology
+topology = torus;
+k = 8;
+n = 2;
+
+// Routing
+routing_function = load_balanced_oblivious;
+
+// Flow control
+num_vcs = 2;
+
+// Traffic
+traffic = uniform;
+injection_rate = 0.15;
+

--- a/src/examples/minimal_oblivious_torus
+++ b/src/examples/minimal_oblivious_torus
@@ -1,0 +1,17 @@
+// Minimal Oblivious Routing Configuration for 8x8 Torus
+
+// Topology
+topology = torus;
+k = 8;
+n = 2;
+
+// Routing
+routing_function = minimal_oblivious;
+
+// Flow control
+num_vcs = 2;
+
+// Traffic
+traffic = uniform;
+injection_rate = 0.15;
+

--- a/src/routefunc.cpp
+++ b/src/routefunc.cpp
@@ -2120,4 +2120,11 @@ void InitializeRoutingMap( const Configuration & config )
 
   gRoutingFunctionMap["chaos_mesh"]  = &chaos_mesh;
   gRoutingFunctionMap["chaos_torus"] = &chaos_torus;
+
+  // ===================================================
+  // Amir Arsalan Yavari
+  gRoutingFunctionMap["minimal_oblivious_torus"]          = &minimal_oblivious_torus;
+  gRoutingFunctionMap["load_balanced_oblivious_torus"]          = &load_balanced_oblivious_torus;
+  // End Amir Arsalan Yavari
+  // ===================================================
 }


### PR DESCRIPTION
Hi :)
For the Interconnection networks courses project, we added `minimal oblivious routing` and `load-balanced oblivious routing` for `torus` to `routefunc.cpp`, along with two config files in the `example` folder. Please review and merge  them if you agree. 
Thanks.